### PR TITLE
Fix missing foreground and background colors in mintty theme

### DIFF
--- a/.mintty/themes/Kaninchenhaus
+++ b/.mintty/themes/Kaninchenhaus
@@ -1,3 +1,6 @@
+ForegroundColour=211,212,221
+BackgroundColour=28,29,28
+CursorColour=198,200,209
 Black=22,24,33
 BoldBlack=107,112,137
 Red=178,108,108


### PR DESCRIPTION
The following fields are missing:
- ForegroundColour
- BackgroundColour
- CursorColour

In the macOS color theme, they are defined as below respectively:
- rgb(211,212,221)
- rgb(28,29,28)
- rgb(198,200,209)